### PR TITLE
fix package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(
-    name='angr-utils',
+    name='bingraphvis',
     version='0.0.1',
     packages=['bingraphvis', 'bingraphvis.angr', 'bingraphvis.angr.x86'],
     install_requires=[


### PR DESCRIPTION
This allows us to `pip install angr-utils` without it getting confused about where to find `bingraphvis`.